### PR TITLE
Added currency formatter method

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Program",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "program": "${workspaceFolder}\\tests\\CurrencyFormatter.js"
+    }
+  ]
+}

--- a/src/CurrencyFormatter/CurrencyFormatter.js
+++ b/src/CurrencyFormatter/CurrencyFormatter.js
@@ -1,0 +1,26 @@
+export const currencyFormatter = (strValue) => {
+  if (typeof strValue === 'undefined' || strValue === null) return '';
+  strValue = strValue.toString();
+  const pos = strValue.indexOf('.');
+  if (pos <= 0) {
+    return '';
+  }
+
+  const left = strValue.substring(0, pos);
+  let right = strValue.substring(pos + 1);
+
+  if (right.length === 1) {
+    right += '0';
+  } else if (right.length > 2) {
+    right = right.substring(0, 2).toString();
+  }
+
+
+  return `${left}.${right}`;
+}
+
+
+// 1.29
+// 1.2
+// "bullshit"
+// "1-1-2023"

--- a/tests/currencyFormatter.test.js
+++ b/tests/currencyFormatter.test.js
@@ -1,0 +1,18 @@
+import { currencyFormatter } from "../src/CurrencyFormatter/CurrencyFormatter";
+
+describe('currencyFormatter', () => {
+  test('should format a number with 1 decimal place', () => {
+    expect(currencyFormatter(1.1)).toEqual("1.10");
+  })
+  test('Should format a number with 2 or more numbers after decimal place down to 2 values', () => {
+    expect(currencyFormatter(1.678765)).toEqual("1.67");
+  })
+  test('If value given is not a number value', () => {
+    expect(currencyFormatter("bullshit")).toEqual('');
+  })
+  test('If value given is null or undefined', () => {
+    expect(currencyFormatter()).toEqual('');
+    expect(currencyFormatter(null)).toEqual('');
+    expect(currencyFormatter(undefined)).toEqual('');
+  })
+})


### PR DESCRIPTION
# Description of change - Added and tested a function to format a string into currency format, truncated to 2 decimal places

## Reason for change - Wanted a useful way to format strings into a currency format

## Summary - 

_Provide an overview...

### What code changes did you make

### References

### Checks

- [x ] Got approval to make the change
- [x ] Created unit tests
